### PR TITLE
[BugFix] fix edge case for short reflection

### DIFF
--- a/reevo.py
+++ b/reevo.py
@@ -331,7 +331,7 @@ class ReEvo:
         # Determine which individual is better or worse
         if ind1["obj"] < ind2["obj"]:
             better_ind, worse_ind = ind1, ind2
-        elif ind1["obj"] > ind2["obj"]:
+        else: # robust in rare cases where two individuals have the same objective value
             better_ind, worse_ind = ind2, ind1
 
         worse_code = filter_code(worse_ind["code"])


### PR DESCRIPTION
This is a minor fix for an edge case for short reflection: if two parents had the same objective value for some reason, the code would fail because of an `if...elif`. Changing `elif` to `else` changes this.

In this edge case the second individual will automatically be better, though -- could this introduce biases?